### PR TITLE
Enable configurable OpenAI API usage

### DIFF
--- a/.github/workflows/daily_arxiv.yml
+++ b/.github/workflows/daily_arxiv.yml
@@ -30,7 +30,8 @@ jobs:
 
     - name: Run script to fetch, filter, and generate report
       env:
-        OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL }}
       run: python src/main.py
 
     - name: Commit and push changes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arxiv Daily AIGC
 
-This is an automated project designed to fetch the latest papers from the Computer Vision (cs.CV) field on arXiv daily, use AI (currently via OpenRouter API) to filter papers related to image/video/multimodal generation, generate structured JSON data and aesthetically pleasing HTML pages, and finally automatically deploy the results to GitHub Pages via GitHub Actions.
+This is an automated project designed to fetch the latest papers from the Computer Vision (cs.CV) field on arXiv daily, use AI (via the OpenAI API) to filter papers related to image/video/multimodal generation, generate structured JSON data and aesthetically pleasing HTML pages, and finally automatically deploy the results to GitHub Pages via GitHub Actions.
 
 ## Features
 
@@ -12,7 +12,7 @@ This is an automated project designed to fetch the latest papers from the Comput
 
 ## Tech Stack
 
-*   **Backend/Script**: Python 3.x (`arxiv`, `requests`, `jinja2`)
+*   **Backend/Script**: Python 3.x (`arxiv`, `requests`, `jinja2`, `openai`)
 *   **Frontend**: HTML5, TailwindCSS (CDN), JavaScript, Framer Motion (CDN)
 *   **Automation**: GitHub Actions
 *   **Deployment**: GitHub Pages
@@ -37,7 +37,7 @@ This is an automated project designed to fetch the latest papers from the Comput
     pip install -r requirements.txt
     ```
 
-4.  **Configure API Key**: This project requires an OpenRouter API Key for AI filtering. You can also modify `src/filter.py` to use other LLM APIs. For security, do not hardcode the key in the code. Set it as an environment variable when running locally. In GitHub Actions, set it as a Secret named `OPENROUTER_API_KEY`.
+4.  **Configure API Key**: This project requires an OpenAI API key for AI filtering. You can change `src/filter.py` to use other LLM APIs if desired. For security, do not hardcode the key in the code. Set it as an environment variable when running locally. In GitHub Actions, set it as a Secret named `OPENAI_API_KEY` and optionally `OPENAI_BASE_URL`.
 
 ## Usage
 
@@ -46,8 +46,10 @@ This is an automated project designed to fetch the latest papers from the Comput
 You can directly run the main script `main.py` to manually trigger a complete process (fetch, filter, generate).
 
 ```bash
-# Ensure the OPENROUTER_API_KEY environment variable is set
-export OPENROUTER_API_KEY='your_openrouter_api_key'
+# Ensure the OPENAI_API_KEY environment variable is set
+export OPENAI_API_KEY='your_openai_api_key'
+# Optionally set a custom base URL, e.g. for Azure/OpenRouter proxies
+# export OPENAI_BASE_URL='https://your-openai-proxy/v1'
 
 # Run the main script (processes today's papers by default)
 python src/main.py
@@ -84,7 +86,7 @@ The project is configured to display results via GitHub Pages. Please visit your
 ├── src/                     # Python script directory
 │   ├── main.py              # Main execution script
 │   ├── scraper.py           # ArXiv scraper module
-│   ├── filter.py            # OpenRouter filter module
+│   ├── filter.py            # Filtering module using the OpenAI API
 │   └── html_generator.py    # HTML generator module
 ├── templates/               # HTML template directory
 │   └── paper_template.html

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -1,6 +1,6 @@
 # Arxiv Daily AIGC
 
-这是一个自动化项目，旨在每日从 arXiv 获取计算机视觉（cs.CV）领域的最新论文，使用 AI (目前通过 OpenRouter API) 筛选出与图像/视频/多模态生成相关的论文，并将结果生成为结构化的 JSON 数据和美观的 HTML 页面，最终通过 GitHub Actions 自动部署到 GitHub Pages。
+这是一个自动化项目，旨在每日从 arXiv 获取计算机视觉（cs.CV）领域的最新论文，使用 AI（默认通过 OpenAI API）筛选出与图像/视频/多模态生成相关的论文，并将结果生成为结构化的 JSON 数据和美观的 HTML 页面，最终通过 GitHub Actions 自动部署到 GitHub Pages。
 
 ## 功能
 
@@ -12,7 +12,7 @@
 
 ## 技术栈
 
-*   **后端/脚本**: Python 3.x (`arxiv`, `requests`, `jinja2`)
+*   **后端/脚本**: Python 3.x (`arxiv`, `requests`, `jinja2`, `openai`)
 *   **前端**: HTML5, TailwindCSS (CDN), JavaScript, Framer Motion (CDN)
 *   **自动化**: GitHub Actions
 *   **部署**: GitHub Pages
@@ -37,7 +37,7 @@
     pip install -r requirements.txt
     ```
 
-4.  **配置 API Key**: 此项目需要 OpenRouter API Key 来进行 AI 筛选，当然你也可以通过修改 `src/filter.py` 调用其他LLM API。为了安全起见，请勿将 Key 硬编码在代码中。在本地运行时，可以通过环境变量设置；在 GitHub Actions 中，请将其设置为名为 `OPENROUTER_API_KEY` 的 Secret。
+4.  **配置 API Key**: 此项目需要 OpenAI API Key 来进行 AI 筛选，你也可以通过修改 `src/filter.py` 调用其他 LLM API。为安全起见，请不要在代码中硬编码 Key。在本地运行时通过环境变量设置；在 GitHub Actions 中，将其设置为名为 `OPENAI_API_KEY`（以及可选的 `OPENAI_BASE_URL`）的 Secret。
 
 ## 使用
 
@@ -46,8 +46,10 @@
 可以直接运行主脚本 `main.py` 来手动触发一次完整的流程（抓取、筛选、生成）。
 
 ```bash
-# 确保设置了 OPENROUTER_API_KEY 环境变量
-export OPENROUTER_API_KEY='your_openrouter_api_key'
+# 确保设置了 OPENAI_API_KEY 环境变量
+export OPENAI_API_KEY='your_openai_api_key'
+# 如有需要，可设置自定义的 base URL，例如代理地址
+# export OPENAI_BASE_URL='https://your-openai-proxy/v1'
 
 # 运行主脚本 (默认处理当天的论文)
 python src/main.py
@@ -84,7 +86,7 @@ python src/main.py
 ├── src/                     # Python 脚本目录
 │   ├── main.py              # 主执行脚本
 │   ├── scraper.py           # ArXiv 爬虫模块
-│   ├── filter.py            # OpenRouter 过滤模块
+│   ├── filter.py            # 使用 OpenAI API 的过滤模块
 │   └── html_generator.py    # HTML 生成模块
 ├── templates/               # HTML 模板目录
 │   └── paper_template.html

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 arxiv
 requests
 Jinja2
+openai

--- a/src/filter.py
+++ b/src/filter.py
@@ -1,110 +1,95 @@
 import os
-import requests
-import time
 import json
 import logging
+import openai
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
-# 从环境变量中获取 OpenRouter API Key
-# 在 GitHub Actions 中，这应该设置为 Secret
-OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY")
-OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions"
+# Environment variables for OpenAI
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+OPENAI_BASE_URL = os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
+MODEL_NAME = os.getenv("OPENAI_MODEL_NAME", "gpt-3.5-turbo")
 
-# 可以选择一个合适的模型，例如免费或低成本的模型进行分类任务
-# 查阅 OpenRouter 文档获取可用模型列表: https://openrouter.ai/docs#models
-# 例如使用 'mistralai/mistral-7b-instruct:free'
-MODEL_NAME = "google/gemini-2.0-flash-001"
+_client = None
 
-def call_openrouter_api(prompt: str, max_tokens: int = 5) -> str | None:
-    """调用 OpenRouter API 并返回模型的响应。
+def _get_client() -> openai.OpenAI:
+    """Create a cached OpenAI client."""
+    global _client
+    if _client is None:
+        if not OPENAI_API_KEY:
+            raise ValueError("OPENAI_API_KEY is not set")
+        _client = openai.OpenAI(api_key=OPENAI_API_KEY, base_url=OPENAI_BASE_URL)
+    return _client
+
+def call_openai_api(prompt: str, max_tokens: int = 5) -> str | None:
+    """Call the OpenAI chat completion API and return the response.
 
     Args:
-        prompt (str): 发送给模型的提示。
-        max_tokens (int): 限制模型响应的最大 token 数。
+        prompt: Prompt sent to the model.
+        max_tokens: Maximum number of tokens in the response.
 
     Returns:
-        str | None: 模型的响应文本，如果发生错误则返回 None。
+        The response text, or ``None`` if an error occurs.
     """
-    if not OPENROUTER_API_KEY:
-        logging.error("未设置 OPENROUTER_API_KEY 环境变量。无法调用 API。")
+    if not OPENAI_API_KEY:
+        logging.error("OPENAI_API_KEY is not set. Cannot call the API.")
         return None
-
-    headers = {
-        "Authorization": f"Bearer {OPENROUTER_API_KEY}",
-        "Content-Type": "application/json",
-    }
-
-    data = {
-        "model": MODEL_NAME,
-        "messages": [
-            {"role": "user", "content": prompt}
-        ],
-        "max_tokens": max_tokens
-    }
 
     try:
-        response = requests.post(OPENROUTER_API_URL, headers=headers, json=data, timeout=30) # 设置超时
-        response.raise_for_status()  # 如果请求失败 (状态码 >= 400)，则抛出 HTTPError
-
-        result = response.json()
-        ai_response = result['choices'][0]['message']['content'].strip()
-        return ai_response
-
-    except requests.exceptions.RequestException as e:
-        logging.error(f"调用 OpenRouter API 时出错: {e}")
-        return None
-    except (KeyError, IndexError) as e:
-        logging.error(f"解析 OpenRouter API 响应时出错: {e}")
-        return None
+        client = _get_client()
+        response = client.chat.completions.create(
+            model=MODEL_NAME,
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=max_tokens,
+        )
+        return response.choices[0].message.content.strip()
     except Exception as e:
-        logging.error(f"调用 OpenRouter API 时发生意外错误: {e}", exc_info=True)
+        logging.error(f"Error calling OpenAI API: {e}")
         return None
 
 def filter_papers_by_topic(papers: list, topic: str = "image or video or multimodal generation") -> list:
-    """使用 OpenRouter API 过滤论文列表，只保留与指定主题相关的论文。
+    """Filter papers using the OpenAI API to keep only those related to ``topic``.
 
     Args:
-        papers (list): 包含论文信息的字典列表，每个字典应包含 'title' 和 'summary'。
-        topic (str): 需要过滤的主题，默认为 "image or video generation"。
+        papers: List of paper dictionaries, each containing ``title`` and ``summary``.
+        topic: Topic string to filter by.
 
     Returns:
-        list: 只包含与主题相关论文的字典列表。
+        List of papers that match the topic.
     """
-    if not OPENROUTER_API_KEY:
-        logging.error("未设置 OPENROUTER_API_KEY 环境变量。无法进行过滤。")
-        # 在没有 API Key 的情况下，可以选择返回原始列表或空列表
-        # 这里返回原始列表，以便流程继续，但会跳过过滤
+    if not OPENAI_API_KEY:
+        logging.error("OPENAI_API_KEY is not set. Skipping filtering.")
+        # return the original list so the pipeline can continue
         return papers
 
     filtered_papers = []
-    logging.info(f"开始使用 OpenRouter API 过滤 {len(papers)} 篇论文，主题: '{topic}'...")
+    logging.info(f"Filtering {len(papers)} papers for topic '{topic}' using OpenAI API...")
 
     for i, paper in enumerate(papers):
         title = paper.get('title', 'N/A')
         summary = paper.get('summary', 'N/A')
 
-        # 构建 Prompt
+        # Build prompt
         prompt = f"Is the following paper primarily about '{topic}'? Answer with only 'yes' or 'no'.\n\nTitle: {title}\nAbstract: {summary}"
 
-        # 调用封装好的 API 函数
-        ai_response = call_openrouter_api(prompt, max_tokens=5)
+        # Call the API
+        ai_response = call_openai_api(prompt, max_tokens=5)
 
         if ai_response is not None:
-            logging.info(f"论文 {i+1}/{len(papers)}: '{title[:50]}...' - AI 回复: {ai_response}")
+            logging.info(f"Paper {i+1}/{len(papers)}: '{title[:50]}...' - AI response: {ai_response}")
             if 'yes' in ai_response.lower():
                 filtered_papers.append(paper)
-            # OpenRouter 对免费模型的速率有限制，可以考虑在 call_openrouter_api 内部或外部添加延时
-            # time.sleep(1) # 暂停 1 秒
+            # Add delay here if your API rate limits require it
         else:
-            logging.warning(f"无法获取论文 '{title[:50]}...' 的 AI 回复，跳过此论文。")
-            continue # 跳过出错的论文
+            logging.warning(f"Failed to get AI response for '{title[:50]}...', skipping.")
+            continue
 
-    logging.info(f"过滤完成，找到 {len(filtered_papers)} 篇与 '{topic}' 相关的论文。")
+    logging.info(f"Filtering complete, {len(filtered_papers)} papers matched topic '{topic}'.")
     return filtered_papers
 
 
+# Template used for rating prompts
 rating_prompt_template = """
 # Role Setting
 You are an experienced researcher in the field of Artificial Intelligence, skilled at quickly evaluating the potential value of research papers.
@@ -142,71 +127,61 @@ Please output the evaluation and explanations in the following JSON format:
 
 
 def rate_papers(papers: list) -> list:
-    """使用 OpenRouter API 对论文进行评分，返回一个包含评分的字典列表。
+    """Rate papers using the OpenAI API and return the updated list.
+
     Args:
-        papers (list): 包含论文信息的字典列表，每个字典应包含 'title' 和'summary'。
+        papers: List of paper dictionaries that contain ``title`` and ``summary``.
+
     Returns:
-        list: 包含论文评分的字典列表，每个字典包含 'title', 'summary', 和 'rating'。
+        The list with rating information added to each paper.
     """
-    if not OPENROUTER_API_KEY:
-        logging.error("未设置 OPENROUTER_API_KEY 环境变量。无法进行评分。")
-        # 在没有 API Key 的情况下，可以选择返回原始列表或空列表
-        # 这里返回原始列表，以便流程继续，但会跳过评分
+    if not OPENAI_API_KEY:
+        logging.error("OPENAI_API_KEY is not set. Skipping rating.")
         return papers
 
-    logging.info(f"开始使用 OpenRouter API 对 {len(papers)} 篇论文进行评分...")
+    logging.info(f"Rating {len(papers)} papers via OpenAI API...")
     for i, paper in enumerate(papers):
         title = paper.get('title', 'N/A')
         summary = paper.get('summary', 'N/A')
-        # 构建 Prompt
+        # Build the evaluation prompt
         prompt = rating_prompt_template % (title, summary)
 
-        # 添加重试逻辑 (最多尝试 2 次)
+        # Retry up to two times if the API call fails
         success = False
         for attempt in range(2):
-            # 调用封装好的 API 函数
-            ai_response = call_openrouter_api(prompt, max_tokens=1000)
+            ai_response = call_openai_api(prompt, max_tokens=1000)
 
             if ai_response is not None:
-                # 检查是否是有效的 JSON 响应
                 try:
-                    # 尝试解析 JSON 响应
-                    # 1. 去掉字符串中的非 JSON 内容 (如果存在)
                     if '```json' in ai_response:
                         ai_response = ai_response.split('```json')[1].split('```')[0]
-                    # 2. json加载
                     rating_data = json.loads(ai_response)
-                    logging.info(f"论文 {i+1}/{len(papers)} (尝试 {attempt+1}): '{title[:50]}...' - AI Rating: {rating_data}")
+                    logging.info(f"Paper {i+1}/{len(papers)} (attempt {attempt+1}): '{title[:50]}...' - Rating: {rating_data}")
                     papers[i].update(rating_data)
                     success = True
-                    break # 成功获取并解析，跳出重试循环
+                    break
                 except json.JSONDecodeError:
-                    logging.warning(f"论文 {i+1}/{len(papers)} (尝试 {attempt+1}): '{title[:50]}...' - AI 回复不是有效的 JSON: {ai_response[:100]}...")
-                    # JSON 解析失败，继续重试 (如果还有尝试次数)
+                    logging.warning(f"Paper {i+1}/{len(papers)} (attempt {attempt+1}): invalid JSON: {ai_response[:100]}...")
                 except Exception as e:
-                    logging.error(f"论文 {i+1}/{len(papers)} (尝试 {attempt+1}): '{title[:50]}...' - 解析响应时发生意外错误: {e}", exc_info=True)
-                    # 其他解析错误，继续重试 (如果还有尝试次数)
+                    logging.error(f"Paper {i+1}/{len(papers)} (attempt {attempt+1}): error parsing response: {e}", exc_info=True)
             else:
-                logging.warning(f"论文 {i+1}/{len(papers)} (尝试 {attempt+1}): 无法获取论文 '{title[:50]}...' 的 AI Rating (API 返回 None)。")
-                # API 调用失败，继续重试 (如果还有尝试次数)
+                logging.warning(f"Paper {i+1}/{len(papers)} (attempt {attempt+1}): API returned None")
 
-            # 如果不是最后一次尝试，则等待后重试
             if attempt < 1:
-                logging.info(f"论文 {i+1}/{len(papers)}: 重试...")
+                logging.info(f"Paper {i+1}/{len(papers)}: retrying...")
 
-        # 如果两次尝试都失败了
         if not success:
-            logging.error(f"论文 {i+1}/{len(papers)}: 两次尝试均未能成功获取和解析 '{title[:50]}...' 的评分，跳过此论文。")
-            continue # 跳过出错的论文
+            logging.error(f"Paper {i+1}/{len(papers)}: failed to retrieve rating after retries, skipping.")
+            continue
 
-    logging.info(f"评分完成。")
+    logging.info("Rating complete.")
     return papers
 
 
-# 可以在这里添加一些测试代码
+# Simple manual test
 if __name__ == '__main__':
-    # 确保设置了 OPENROUTER_API_KEY 环境变量才能运行测试
-    if OPENROUTER_API_KEY:
+    # Ensure OPENAI_API_KEY is set before running this test
+    if OPENAI_API_KEY:
         test_papers = [
             {
                 'title': 'Generative Adversarial Networks for Image Synthesis ',
@@ -221,13 +196,13 @@ if __name__ == '__main__':
                 'summary': 'A novel approach to generating high-fidelity video sequences using latent diffusion models.'
             }
         ]
-        logging.info("\n--- 开始测试 filter_papers_by_topic --- ")
+        logging.info("\n--- Testing filter_papers_by_topic ---")
         filtered = filter_papers_by_topic(test_papers)
         rated = rate_papers(filtered)
 
-        logging.info("\n--- 过滤后的论文 --- ")
+        logging.info("\n--- Filtered papers ---")
         for paper in filtered:
             logging.info(f"- {paper['title']}\t{paper.get('overall_priority_score', None)}")
-        logging.info("--- 测试结束 ---")
+        logging.info("--- Test finished ---")
     else:
-        logging.warning("请设置 OPENROUTER_API_KEY 环境变量以运行测试。")
+        logging.warning("Please set OPENAI_API_KEY to run the test.")

--- a/src/main.py
+++ b/src/main.py
@@ -50,7 +50,7 @@ def main(target_date: date):
 
         # --- 2. 过滤论文、论文打分 --- #
         logging.info("步骤 2: 使用 AI 过滤论文并打分 (主题: image/video/multimodal generation)...")
-        # 注意：filter_papers_by_topic 依赖 OPENROUTER_API_KEY 环境变量
+        # Note: filter_papers_by_topic requires OPENAI_API_KEY environment variable
         filtered_papers = filter_papers_by_topic(raw_papers, topic="general image/video/multimodal generation")
         filtered_papers = rate_papers(filtered_papers)
         # 将filtered_papers按照overall_priority_score降序排序


### PR DESCRIPTION
## Summary
- allow specifying `OPENAI_API_KEY`, `OPENAI_BASE_URL`, and `OPENAI_MODEL_NAME`
- update filtering and rating code to use OpenAI SDK
- document new environment variables in both READMEs
- update workflow to pass secrets
- add `openai` to requirements

## Testing
- `python -m pip install -q -r requirements.txt`
- `python -m py_compile src/*.py`

------
https://chatgpt.com/codex/tasks/task_b_687cb6c9933883328583c1a5faabad2a